### PR TITLE
PET-1192 - Fix pod with CVE panel query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `starboard`, `logr`, and `controller-runtime` dependency versions.
 - Remove unneeded `releaseRevision` annotation from deployment.
 
+### Fixed
+
+- Helm, fix incomplete metric name in pods with high/critical CVEs panel
+
 ## [0.1.4] - 2021-12-14
 
 ### Changed

--- a/helm/starboard-exporter/templates/grafana-dashboard.yaml
+++ b/helm/starboard-exporter/templates/grafana-dashboard.yaml
@@ -598,7 +598,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "topk(10, sum(starboard_exporter_vulnerabilityreport_image_vulnerability{severity=~\"CRITICAL|HIGH\"}) by (image_repository, image_tag))",
+              "expr": "topk(10, sum(starboard_exporter_vulnerabilityreport_image_vulnerability_severity_count{severity=~\"CRITICAL|HIGH\"}) by (image_repository, image_tag))",
               "format": "table",
               "instant": true,
               "interval": "",


### PR DESCRIPTION
Fixes #41 

The query was using an incomplete metrics name that was missing the
"_severity_count" postfix.

## Checklist

- [X] Update changelog in CHANGELOG.md.
