### PR TITLE
Include registry in image_repository label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include the registry server in `image_repository` labels.
+- Add the `image_registry` label exposing the image registry.
+
+### Changed
+
 - Bump `golang`, `prometheus`, and `starboard` dependency versions.
-- Update Grafana dashboard to use plugin version 8.3.2.
+- Update Grafana dashboard to use plugin version 8.3.2 and the new label.
 
 ## [0.2.1] - 2022-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Include the registry server in `image_repository` labels.
 - Bump `golang`, `prometheus`, and `starboard` dependency versions.
+- Update Grafana dashboard to use plugin version 8.3.2.
 
 ## [0.2.1] - 2022-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Include the registry server in `image_repository` labels.
+- Bump `golang`, `prometheus`, and `starboard` dependency versions.
+
 ## [0.2.1] - 2022-01-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A summary series exposes the count of CVEs of each severity reported in a given 
 starboard_exporter_vulnerabilityreport_image_vulnerability_severity_count{
     image_digest="",
     image_namespace="demo",
+    image_registry="quay.io",
     image_repository="giantswarm/starboard-operator",
     image_tag="0.11.0",
     report_name="replicaset-starboard-app-6894945788-starboard-app",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ starboard_exporter_vulnerabilityreport_image_vulnerability{
     fixed_resource_version="1.1.1l-r0",
     image_digest="",
     image_namespace="demo",
-    image_registry="quay.io/",
+    image_registry="quay.io",
     image_repository="giantswarm/starboard-operator",
     image_tag="0.11.0",
     installed_resource_version="1.1.1k-r0",

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ starboard_exporter_vulnerabilityreport_image_vulnerability{
     fixed_resource_version="1.1.1l-r0",
     image_digest="",
     image_namespace="demo",
+    image_registry="quay.io/",
     image_repository="giantswarm/starboard-operator",
     image_tag="0.11.0",
     installed_resource_version="1.1.1k-r0",

--- a/controllers/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport_controller.go
@@ -272,8 +272,10 @@ func reportValueFor(field string, report *aqua.VulnerabilityReport) string {
 		return report.Name
 	case "image_namespace":
 		return report.Namespace
+	case "image_registry":
+		return report.Report.Registry.Server
 	case "image_repository":
-		return fmt.Sprintf("%s/%s", report.Report.Registry.Server, report.Report.Artifact.Repository)
+		return report.Report.Artifact.Repository
 	case "image_tag":
 		return report.Report.Artifact.Tag
 	case "image_digest":

--- a/controllers/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport_controller.go
@@ -273,7 +273,7 @@ func reportValueFor(field string, report *aqua.VulnerabilityReport) string {
 	case "image_namespace":
 		return report.Namespace
 	case "image_repository":
-		return report.Report.Artifact.Repository
+		return fmt.Sprintf("%s/%s", report.Report.Registry.Server, report.Report.Artifact.Repository)
 	case "image_tag":
 		return report.Report.Artifact.Tag
 	case "image_digest":

--- a/controllers/vulnerabilityreport_metrics.go
+++ b/controllers/vulnerabilityreport_metrics.go
@@ -39,6 +39,11 @@ var metricLabels = []VulnerabilityLabel{
 		Scope:  FieldScopeReport,
 	},
 	{
+		Name:   "image_registry",
+		Groups: []string{LabelGroupAll, labelGroupSummary},
+		Scope:  FieldScopeReport,
+	},
+	{
 		Name:   "image_repository",
 		Groups: []string{LabelGroupAll, labelGroupSummary},
 		Scope:  FieldScopeReport,

--- a/helm/starboard-exporter/templates/grafana-dashboard.yaml
+++ b/helm/starboard-exporter/templates/grafana-dashboard.yaml
@@ -13,6 +13,39 @@ metadata:
 data:
   grafana-starboard.json: |-
     {
+      "__elements": [],
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "8.3.2"
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        },
+        {
+          "type": "panel",
+          "id": "stat",
+          "name": "Stat",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "table",
+          "name": "Table",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "timeseries",
+          "name": "Time series",
+          "version": ""
+        }
+      ],
       "annotations": {
         "list": [
           {
@@ -22,19 +55,28 @@ data:
             "hide": true,
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
             "type": "dashboard"
           }
         ]
       },
       "editable": true,
-      "gnetId": null,
+      "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 56,
-      "iteration": 1638185708499,
+      "id": null,
+      "iteration": 1644852715758,
       "links": [],
+      "liveNow": false,
       "panels": [
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -80,7 +122,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "8.3.2",
           "targets": [
             {
               "exemplar": true,
@@ -94,7 +136,9 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -140,7 +184,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "8.3.2",
           "targets": [
             {
               "exemplar": true,
@@ -154,7 +198,9 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -200,7 +246,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "8.3.2",
           "targets": [
             {
               "exemplar": true,
@@ -214,7 +260,9 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -260,7 +308,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "8.3.2",
           "targets": [
             {
               "exemplar": true,
@@ -274,7 +322,9 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -320,7 +370,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "8.3.2",
           "targets": [
             {
               "exemplar": true,
@@ -334,7 +384,9 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -380,7 +432,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "8.3.2",
           "targets": [
             {
               "exemplar": true,
@@ -394,7 +446,9 @@ data:
           "type": "stat"
         },
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "description": "",
           "fieldConfig": {
             "defaults": {
@@ -476,7 +530,9 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -557,7 +613,10 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": "$datasource",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -592,12 +651,23 @@ data:
           },
           "id": 13,
           "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
             "showHeader": true
           },
-          "pluginVersion": "8.0.3",
+          "pluginVersion": "8.3.2",
           "targets": [
             {
-              "exemplar": true,
+              "datasource": {
+                "type": "prometheus",
+                "uid": "$datasource"
+              },
+              "exemplar": false,
               "expr": "topk(10, sum(starboard_exporter_vulnerabilityreport_image_vulnerability_severity_count{severity=~\"CRITICAL|HIGH\"}) by (image_registry, image_repository, image_tag))",
               "format": "table",
               "instant": true,
@@ -622,8 +692,8 @@ data:
           "type": "table"
         }
       ],
-      "refresh": "10s",
-      "schemaVersion": 30,
+      "refresh": "",
+      "schemaVersion": 33,
       "style": "dark",
       "templating": {
         "list": [
@@ -633,8 +703,6 @@ data:
               "text": "default",
               "value": "default"
             },
-            "description": null,
-            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "Datasource",
@@ -658,6 +726,7 @@ data:
       "timezone": "",
       "title": "Security: Starboard Dashboard",
       "uid": "CK_Th9c7k",
-      "version": 1
+      "version": 1,
+      "weekStart": ""
     }
 {{- end -}}

--- a/helm/starboard-exporter/templates/grafana-dashboard.yaml
+++ b/helm/starboard-exporter/templates/grafana-dashboard.yaml
@@ -692,7 +692,7 @@ data:
           "type": "table"
         }
       ],
-      "refresh": "",
+      "refresh": "10s",
       "schemaVersion": 33,
       "style": "dark",
       "templating": {

--- a/helm/starboard-exporter/templates/grafana-dashboard.yaml
+++ b/helm/starboard-exporter/templates/grafana-dashboard.yaml
@@ -598,7 +598,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "topk(10, sum(starboard_exporter_vulnerabilityreport_image_vulnerability_severity_count{severity=~\"CRITICAL|HIGH\"}) by (image_repository, image_tag))",
+              "expr": "topk(10, sum(starboard_exporter_vulnerabilityreport_image_vulnerability_severity_count{severity=~\"CRITICAL|HIGH\"}) by (image_registry, image_repository, image_tag))",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -607,6 +607,18 @@ data:
             }
           ],
           "title": "Pods with Critical/High CVEs",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ],
           "type": "table"
         }
       ],


### PR DESCRIPTION
Towards https://github.com/giantswarm/starboard-exporter/issues/62
Adds the `image_registry` label to store the registry hosting the image.
Also uses this new label in one dashboard panel.

## Checklist

- [x] Update changelog in CHANGELOG.md.
