### PR TITLE
feat: add metrics for configauditreport summary

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -9,4 +9,9 @@ resources:
   group: aquasecurity.github.io
   kind: VulnerabilityReport
   version: v1alpha1
+- controller: true
+  domain: giantswarm
+  group: aquasecurity.github.io
+  kind: ConfigAuditReport
+  version: v1alpha1
 version: "3"

--- a/controllers/configauditreport/configauditreport_controller.go
+++ b/controllers/configauditreport/configauditreport_controller.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configauditreport
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	aqua "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
+)
+
+// ConfigAuditReportReconciler reconciles a ConfigAuditReport object
+type ConfigAuditReportReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=aquasecurity.github.io.giantswarm,resources=configauditreports,verbs=get;list;watch;create;update;patch;delete
+func (r *ConfigAuditReportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = log.FromContext(ctx)
+	_ = r.Log.WithValues("configauditreport", req.NamespacedName)
+
+	report := &aqua.ConfigAuditReport{}
+	if err := r.Client.Get(ctx, req.NamespacedName, report); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Most likely the report was deleted.
+			return ctrl.Result{}, nil
+		}
+
+		// Error reading the object.
+		r.Log.Error(err, "Unable to read configauditreport")
+		return ctrl.Result{}, err
+	}
+
+	if report.DeletionTimestamp.IsZero() {
+		r.Log.Info(fmt.Sprintf("Reconciled %s || Found (D/W/P): %d/%d/%d",
+			req.NamespacedName,
+			report.Report.Summary.DangerCount,
+			report.Report.Summary.WarningCount,
+			report.Report.Summary.PassCount,
+		))
+
+		// Publish summary metrics for this report.
+		publishSummaryMetrics(report)
+
+	}
+
+	return defaultRequeue(), nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ConfigAuditReportReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&aqua.ConfigAuditReport{}).
+		Complete(r)
+	if err != nil {
+		return errors.Wrap(err, "failed setting up controller with controller manager")
+	}
+
+	return nil
+}
+
+func getCountPerSeverity(report *aqua.ConfigAuditReport) map[string]float64 {
+	// Format is e.g. {danger: 10}.
+	return map[string]float64{
+		string(aqua.ConfigAuditSeverityDanger):  float64(report.Report.Summary.DangerCount),
+		string(aqua.ConfigAuditSeverityWarning): float64(report.Report.Summary.WarningCount),
+		"pass":                                  float64(report.Report.Summary.PassCount),
+	}
+}
+
+func publishSummaryMetrics(report *aqua.ConfigAuditReport) {
+	summaryValues := valuesForReport(report, metricLabels)
+
+	// Add the severity label after the standard labels and expose each severity metric.
+	for severity, count := range getCountPerSeverity(report) {
+		v := summaryValues
+		v["severity"] = severity
+
+		// Expose the metric.
+		ConfigAuditSummary.With(
+			v,
+		).Set(count)
+	}
+}
+
+func valuesForReport(report *aqua.ConfigAuditReport, labels []string) map[string]string {
+	result := map[string]string{}
+	for _, label := range labels {
+		result[label] = reportValueFor(label, report)
+	}
+	return result
+}
+
+func reportValueFor(field string, report *aqua.ConfigAuditReport) string {
+	switch field {
+	case "resource_name":
+		return report.Name
+	case "resource_namespace":
+		return report.Namespace
+	case "severity":
+		return "" // this value will be overwritten on publishSummaryMetrics
+	default:
+		// Error?
+		return ""
+	}
+}
+
+func defaultRequeue() reconcile.Result {
+	return ctrl.Result{
+		Requeue:      true,
+		RequeueAfter: time.Minute * 5,
+	}
+}

--- a/controllers/configauditreport/configauditreport_metrics.go
+++ b/controllers/configauditreport/configauditreport_metrics.go
@@ -1,0 +1,35 @@
+package configauditreport
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	metricNamespace = "starboard_exporter"
+	metricSubsystem = "configauditreport"
+)
+
+var metricLabels = []string{
+	"resource_name",
+	"resource_namespace",
+	"severity",
+}
+
+// Gauge for the count of all config audit rules summary
+var (
+	ConfigAuditSummary = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "resource_checks_summary_count",
+			Help:      "Exposes the number of checks of a particular severity.",
+		},
+		metricLabels,
+	)
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(ConfigAuditSummary)
+}

--- a/helm/starboard-exporter/templates/rbac.yaml
+++ b/helm/starboard-exporter/templates/rbac.yaml
@@ -9,6 +9,7 @@ rules:
       - aquasecurity.github.io
     resources:
       - vulnerabilityreports
+      - configauditreports
     verbs:
       - get
       - list

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	aqua "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 
 	"github.com/giantswarm/starboard-exporter/controllers"
+	"github.com/giantswarm/starboard-exporter/controllers/configauditreport"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -120,6 +121,15 @@ func main() {
 		TargetLabels: targetLabels,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VulnerabilityReport")
+		os.Exit(1)
+	}
+
+	if err = (&configauditreport.ConfigAuditReportReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("ConfigAuditReport"),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ConfigAuditReport")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
This PR add support for `configauditreport` custom resource metrics

Should I move the `vulnerabityreport_*.go` to its own package `vulnerabilityreports` ?

I plan to do the same with the `cisbenchmarkreport`, so any feedback is welcome!