### PR TITLE
[HELM] feat: added missing monitoring options in values.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added missing monitoring options in the Helm chart values.yaml
+
 ## [0.4.1] - 2022-04-26
 
 ### Added
 
 - Spread (jitter) re-queueing of reports by +/- 10% by default to help smooth resource utilization.
-- Added missing monitoring options in the Helm chart values.yaml
 
 ## [0.4.0] - 2022-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Spread (jitter) re-queueing of reports by +/- 10% by default to help smooth resource utilization.
+- Added missing monitoring options in the Helm chart values.yaml
 
 ## [0.4.0] - 2022-04-22
 

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -44,9 +44,11 @@ exporter:
 monitoring:
   serviceMonitor:
     enabled: true
+    labels: {}
 
   grafanaDashboard:
     enabled: true
+    # namespace: ""
 
 psp:
   enabled: true


### PR DESCRIPTION
Signed-off-by: David <davidcalvertfr@gmail.com>

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] (Giant Swarm) If creating a release, bump the `version` and `appVersion` in Chart.yaml.

Hi,

Theses configuration options are present in the template files but not in the values.

Templates:
- [ServiceMonitor](https://github.com/giantswarm/starboard-exporter/blob/main/helm/starboard-exporter/templates/servicemonitor.yaml#L10)
- [GrafanaDashboard](https://github.com/giantswarm/starboard-exporter/blob/main/helm/starboard-exporter/templates/grafana-dashboard.yaml#L8)

It's easier for the users to have all the possible configuration options directly in the `values.yaml` file.

Updated `CHANGELOG.md`, let me know if anything's missing in my PR.

David
