### PR TITLE
Remove finalizers

### DIFF
--- a/controllers/configauditreport/configauditreport_controller.go
+++ b/controllers/configauditreport/configauditreport_controller.go
@@ -105,44 +105,6 @@ func (r *ConfigAuditReportReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}
 
-	// if report.DeletionTimestamp.IsZero() && shouldOwn {
-	// 	// Give the report our finalizer if it doesn't have one.
-	// 	if !utils.SliceContains(report.GetFinalizers(), ConfigAuditReportFinalizer) {
-	// 		ctrlutil.AddFinalizer(report, ConfigAuditReportFinalizer)
-	// 		if err := r.Update(ctx, report); err != nil {
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 	}
-
-	// 	// Publish summary metrics for this report.
-	// 	publishSummaryMetrics(report)
-
-	// 	// Add a label to this report so any previous owners will reconcile and drop the metric.
-	// 	report.Labels[controllers.ShardOwnerLabel] = r.ShardHelper.PodIP
-	// 	err := r.Client.Update(ctx, report, &client.UpdateOptions{})
-	// 	if err != nil {
-	// 		r.Log.Error(err, "unable to add shard owner label")
-	// 	}
-
-	// } else {
-	// 	// Unfortunately, we can't yet clear the series based on one label value,
-	// 	// we have to reconstruct all of the label values to delete the series.
-	// 	// That's the only reason the finalizer is needed at all.
-	// 	// So we first clear our metrics for the report, and then remove the finalizer
-	// 	// if we're the shard which owns this report.
-
-	// 	// Drop the report from our metrics.
-	// 	r.clearImageMetrics(report)
-
-	// 	if shouldOwn && utils.SliceContains(report.GetFinalizers(), ConfigAuditReportFinalizer) {
-	// 		// Remove the finalizer if we're the shard owner.
-	// 		ctrlutil.RemoveFinalizer(report, ConfigAuditReportFinalizer)
-	// 		if err := r.Update(ctx, report); err != nil {
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 	}
-	// }
-
 	return utils.JitterRequeue(controllers.DefaultRequeueDuration, r.MaxJitterPercent, r.Log), nil
 }
 
@@ -157,22 +119,6 @@ func (r *ConfigAuditReportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return nil
 }
-
-// func (r *ConfigAuditReportReconciler) clearImageMetrics(report *aqua.ConfigAuditReport) {
-// 	// clear summary metrics
-// 	summaryValues := valuesForReport(report, metricLabels)
-
-// 	// Delete the series for each severity.
-// 	for severity := range getCountPerSeverity(report) {
-// 		v := summaryValues
-// 		v["severity"] = severity
-
-// 		// Delete the metric.
-// 		ConfigAuditSummary.Delete(
-// 			v,
-// 		)
-// 	}
-// }
 
 func RequeueReportsForPod(c client.Client, log logr.Logger, podIP string) {
 	reportList := &aqua.ConfigAuditReportList{}

--- a/controllers/configauditreport/configauditreport_controller.go
+++ b/controllers/configauditreport/configauditreport_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -187,6 +188,8 @@ func valuesForReport(report *aqua.ConfigAuditReport, labels []string) map[string
 
 func reportValueFor(field string, report *aqua.ConfigAuditReport) string {
 	switch field {
+	case "report_name":
+		return apitypes.NamespacedName{Name: report.Name, Namespace: report.Namespace}.String()
 	case "resource_name":
 		return report.Name
 	case "resource_namespace":

--- a/controllers/configauditreport/configauditreport_controller.go
+++ b/controllers/configauditreport/configauditreport_controller.go
@@ -195,7 +195,7 @@ func reportValueFor(field string, report *aqua.ConfigAuditReport) string {
 	case "resource_namespace":
 		return report.Namespace
 	case "severity":
-		return "" // this value will be overwritten on publishSummaryMetrics
+		return "" // this value will be overwritten in publishSummaryMetrics
 	default:
 		// Error?
 		return ""

--- a/controllers/configauditreport/configauditreport_metrics.go
+++ b/controllers/configauditreport/configauditreport_metrics.go
@@ -11,6 +11,7 @@ const (
 )
 
 var metricLabels = []string{
+	"report_name",
 	"resource_name",
 	"resource_namespace",
 	"severity",

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -82,6 +82,7 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 			r.Log.Error(err, "Unable to read report")
 			return ctrl.Result{}, err
 		}
+
 		r.Log.Info(fmt.Sprintf("Reconciled %s || Found (C/H/M/L/N/U): %d/%d/%d/%d/%d/%d",
 			req.NamespacedName,
 			report.Report.Summary.CriticalCount,
@@ -93,6 +94,15 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 		))
 		// Publish summary and CVE metrics for this report.
 		r.publishImageMetrics(report)
+
+
+		if utils.SliceContains(report.GetFinalizers(), VulnerabilityReportFinalizer) {
+			// Remove the finalizer if we're the shard owner.
+			ctrlutil.RemoveFinalizer(report, VulnerabilityReportFinalizer)
+			if err := r.Update(ctx, report); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 
 		// Add a label to this report so any previous owners will reconcile and drop the metric.
 		report.Labels[controllers.ShardOwnerLabel] = r.ShardHelper.PodIP
@@ -295,6 +305,7 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
 	reportValues := valuesForReport(report, targetLabels)
+	fmt.Printf("setting values for report %s/%s\n", report.Name, report.Report.)
 	fmt.Printf("setting values for report %s\n", reportValues["report_name"])
 	fmt.Printf("report:\n%v\n", report)
 	for _, v := range report.Report.Vulnerabilities {

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -207,9 +207,7 @@ func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager) error
 // }
 
 func (r *VulnerabilityReportReconciler) publishImageMetrics(report *aqua.VulnerabilityReport) {
-	fmt.Printf("Report before publish: %s\n", report.Name)
 	publishSummaryMetrics(report)
-	fmt.Printf("Report after publish: %s\n", report.Name)
 	// If we have custom metrics to expose, do it.
 	if len(r.TargetLabels) > 0 {
 		publishCustomMetrics(report, r.TargetLabels)
@@ -275,10 +273,7 @@ func getCountPerSeverity(report *aqua.VulnerabilityReport) map[string]float64 {
 // }
 
 func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
-	fmt.Println("publishSummaryMetrics()")
 	summaryValues := valuesForReport(report, LabelsForGroup(labelGroupSummary))
-	fmt.Printf("setting values for report:\nreport.Name: %s\nreport.ObjectMeta.Name: %s\nsummaryValues[report_name]: %s\n",
-		report.Name, report.ObjectMeta.Name, summaryValues["report_name"])
 	// Add the severity label after the standard labels and expose each severity metric.
 	for severity, count := range getCountPerSeverity(report) {
 		v := summaryValues
@@ -310,11 +305,7 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 // }
 
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
-	fmt.Println("publishCustomMetrics()")
 	reportValues := valuesForReport(report, targetLabels)
-	fmt.Printf("setting values for report:\nreport.Name: %s\nreport.ObjectMeta.Name: %s\nreportValues[report_name]: %s\n",
-		report.Name, report.ObjectMeta.Name, reportValues["report_name"])
-	fmt.Printf("report_namespace:\n report.Namespace: %s\n reportValues[image_namespace]: %s\n", report.Namespace, reportValues["image_namespace"])
 	// fmt.Printf("report:\n%v\n", report)
 	for _, v := range report.Report.Vulnerabilities {
 		vulnValues := valuesForVulnerability(v, targetLabels)
@@ -342,10 +333,8 @@ func valuesForReport(report *aqua.VulnerabilityReport, labels []VulnerabilityLab
 	for _, label := range labels {
 		if label.Scope == FieldScopeReport {
 			result[label.Name] = reportValueFor(label.Name, report)
-			fmt.Printf("result[%s]: %s\n", label.Name, result[label.Name])
 		}
 	}
-	fmt.Printf("result: %v\n", result)
 	return result
 }
 
@@ -362,7 +351,6 @@ func valuesForVulnerability(vuln aqua.Vulnerability, labels []VulnerabilityLabel
 func reportValueFor(field string, report *aqua.VulnerabilityReport) string {
 	switch field {
 	case "report_name":
-		fmt.Printf("found report_name: %s\n", report.Name)
 		return report.Name
 	case "image_namespace":
 		return report.Namespace

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -295,7 +295,7 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
 	reportValues := valuesForReport(report, targetLabels)
-
+	fmt.Println(fmt.Sprintf("setting values for report %s", reportValues["report_name"]))
 	for _, v := range report.Report.Vulnerabilities {
 		vulnValues := valuesForVulnerability(v, targetLabels)
 

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -352,8 +352,7 @@ func valuesForVulnerability(vuln aqua.Vulnerability, labels []VulnerabilityLabel
 func reportValueFor(field string, report *aqua.VulnerabilityReport) string {
 	switch field {
 	case "report_name":
-		return apitypes.NamespacedName{Name: report.Name, Namespace: report.Namespace}
-		// return report.Name
+		return apitypes.NamespacedName{Name: report.Name, Namespace: report.Namespace}.String()
 	case "image_namespace":
 		return report.Namespace
 	case "image_registry":

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -68,10 +68,6 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 	// The report has changed, meaning our metrics are out of date for this report. Clear them.
 	deletedSummaries := VulnerabilitySummary.DeletePartialMatch(prometheus.Labels{"report_name": req.NamespacedName.String()})
 	deletedDetails := VulnerabilityInfo.DeletePartialMatch(prometheus.Labels{"report_name": req.NamespacedName.String()})
-	r.Log.Info(fmt.Sprintf("cleared %d summary and %d detail metrics", deletedSummaries, deletedDetails))
-
-	r.Log.Info(fmt.Sprintf("Peer %s should handle report %s", r.ShardHelper.GetShardOwner(req.NamespacedName.String()), req.NamespacedName.String()))
-	r.Log.Info(fmt.Sprintf("This instance should own report: %v", r.ShardHelper.ShouldOwn(req.NamespacedName.String())))
 
 	shouldOwn := r.ShardHelper.ShouldOwn(req.NamespacedName.String())
 	if shouldOwn {
@@ -115,57 +111,11 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 		if err != nil {
 			r.Log.Error(err, "unable to add shard owner label")
 		}
+	} else {
+		if deletedSummaries > 0 || deletedDetails > 0 {
+			r.Log.Info(fmt.Sprintf("cleared %d summary and %d detail metrics", deletedSummaries, deletedDetails))
+		}
 	}
-
-	// If we are the shard owner for this report, try to fetch it and expose metrics for it.
-
-	// Once deleting metrics based on partial matches is supported, the logic here will change so we clear the metric for all names not belonging to our shard.
-	// Then we can only fetch reports for our shard. For now, we'll try to get the report once even if it isn't our shard so that we can later clear the metric.
-
-	// We have fetched the report and have four possibilities:
-	// - Not deleting + belongs to our shard 			--> give it our label (to trigger reconciliation by any previous owner) and expose the metric.
-	// - Not deleting + does not belong to our shard 	--> remove it from our metrics. Keep the finalizer.
-	// - Deleting + belongs to our shard				--> remove it from our metrics. Remove the finalizer.
-	// - Deleting + does not belong to our shard		--> remove it from our metrics. Keep the finalizer.
-
-	// if report.DeletionTimestamp.IsZero() && shouldOwn {
-
-	// 	// Give the report our finalizer if it doesn't have one.
-	// 	if !utils.SliceContains(report.GetFinalizers(), VulnerabilityReportFinalizer) {
-	// 		ctrlutil.AddFinalizer(report, VulnerabilityReportFinalizer)
-	// 		if err := r.Update(ctx, report); err != nil {
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 	}
-
-	// 	r.Log.Info(fmt.Sprintf("Reconciled %s || Found (C/H/M/L/N/U): %d/%d/%d/%d/%d/%d",
-	// 		req.NamespacedName,
-	// 		report.Report.Summary.CriticalCount,
-	// 		report.Report.Summary.HighCount,
-	// 		report.Report.Summary.MediumCount,
-	// 		report.Report.Summary.LowCount,
-	// 		report.Report.Summary.NoneCount,
-	// 		report.Report.Summary.UnknownCount,
-	// 	))
-
-	// } else {
-	// 	// Unfortunately, we can't yet clear the series based on one label value,
-	// 	// we have to reconstruct all of the label values to delete the series.
-	// 	// That's the only reason the finalizer is needed at all.
-	// 	// So we first clear our metrics for the report, and then remove the finalizer
-	// 	// if we're the shard which owns this report.
-
-	// 	// Drop the report from our metrics.
-	// 	r.clearImageMetrics(report)
-
-	// 	if shouldOwn && utils.SliceContains(report.GetFinalizers(), VulnerabilityReportFinalizer) {
-	// 		// Remove the finalizer if we're the shard owner.
-	// 		ctrlutil.RemoveFinalizer(report, VulnerabilityReportFinalizer)
-	// 		if err := r.Update(ctx, report); err != nil {
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 	}
-	// }
 
 	return utils.JitterRequeue(controllers.DefaultRequeueDuration, r.MaxJitterPercent, r.Log), nil
 }
@@ -196,16 +146,6 @@ func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager) error
 
 	return nil
 }
-
-// func (r *VulnerabilityReportReconciler) clearImageMetrics(report *aqua.VulnerabilityReport) {
-
-// 	clearSummaryMetrics(report)
-
-// 	// If we have custom metrics to delete, do it.
-// 	if len(r.TargetLabels) > 0 {
-// 		clearCustomMetrics(report, r.TargetLabels)
-// 	}
-// }
 
 func (r *VulnerabilityReportReconciler) publishImageMetrics(report *aqua.VulnerabilityReport) {
 	publishSummaryMetrics(report)
@@ -258,21 +198,6 @@ func getCountPerSeverity(report *aqua.VulnerabilityReport) map[string]float64 {
 	}
 }
 
-// func clearSummaryMetrics(report *aqua.VulnerabilityReport) {
-// 	summaryValues := valuesForReport(report, LabelsForGroup(labelGroupSummary))
-
-// 	// Delete the series for each severity.
-// 	for severity := range getCountPerSeverity(report) {
-// 		v := summaryValues
-// 		v["severity"] = severity
-
-// 		// Expose the metric.
-// 		VulnerabilitySummary.Delete(
-// 			v,
-// 		)
-// 	}
-// }
-
 func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 	summaryValues := valuesForReport(report, LabelsForGroup(labelGroupSummary))
 	// Add the severity label after the standard labels and expose each severity metric.
@@ -287,27 +212,8 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 	}
 }
 
-// func clearCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
-// 	reportValues := valuesForReport(report, targetLabels)
-
-// 	for _, v := range report.Report.Vulnerabilities {
-// 		vulnValues := valuesForVulnerability(v, targetLabels)
-
-// 		// Include the Report-level values.
-// 		for label, value := range reportValues {
-// 			vulnValues[label] = value
-// 		}
-
-// 		// Delete the metric
-// 		VulnerabilityInfo.Delete(
-// 			vulnValues,
-// 		)
-// 	}
-// }
-
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
 	reportValues := valuesForReport(report, targetLabels)
-	// fmt.Printf("report:\n%v\n", report)
 	for _, v := range report.Report.Vulnerabilities {
 		vulnValues := valuesForVulnerability(v, targetLabels)
 
@@ -352,6 +258,7 @@ func valuesForVulnerability(vuln aqua.Vulnerability, labels []VulnerabilityLabel
 func reportValueFor(field string, report *aqua.VulnerabilityReport) string {
 	switch field {
 	case "report_name":
+		// Construct the namespacedname which we'll later be given at reconciliation.
 		return apitypes.NamespacedName{Name: report.Name, Namespace: report.Namespace}.String()
 	case "image_namespace":
 		return report.Namespace

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -273,7 +273,8 @@ func getCountPerSeverity(report *aqua.VulnerabilityReport) map[string]float64 {
 func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 	fmt.Println("publishSummaryMetrics()")
 	summaryValues := valuesForReport(report, LabelsForGroup(labelGroupSummary))
-
+	fmt.Printf("setting values for report:\nreport.Name: %s\nreport.ObjectMeta.Name: %s\nsummaryValues[report_name]: %s\n",
+		report.Name, report.ObjectMeta.Name, summaryValues["report_name"])
 	// Add the severity label after the standard labels and expose each severity metric.
 	for severity, count := range getCountPerSeverity(report) {
 		v := summaryValues

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -296,6 +296,7 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
 	reportValues := valuesForReport(report, targetLabels)
 	fmt.Printf("setting values for report %s\n", reportValues["report_name"])
+	fmt.Printf("report:\n%v\n", report)
 	for _, v := range report.Report.Vulnerabilities {
 		vulnValues := valuesForVulnerability(v, targetLabels)
 

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -335,8 +335,10 @@ func valuesForReport(report *aqua.VulnerabilityReport, labels []VulnerabilityLab
 	for _, label := range labels {
 		if label.Scope == FieldScopeReport {
 			result[label.Name] = reportValueFor(label.Name, report)
+			fmt.Printf("result[%s]: %s", label.Name, result[label.Name])
 		}
 	}
+	fmt.Printf("result: %v\n", result)
 	return result
 }
 

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -94,7 +95,6 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 		))
 		// Publish summary and CVE metrics for this report.
 		r.publishImageMetrics(report)
-
 
 		if utils.SliceContains(report.GetFinalizers(), VulnerabilityReportFinalizer) {
 			// Remove the finalizer if we're the shard owner.
@@ -305,7 +305,7 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
 	reportValues := valuesForReport(report, targetLabels)
-	fmt.Printf("setting values for report %s/%s\n", report.Name, report.Report.)
+	fmt.Printf("setting values for report %s/%s\n", report.Name, report.ObjectMeta.Name)
 	fmt.Printf("setting values for report %s\n", reportValues["report_name"])
 	fmt.Printf("report:\n%v\n", report)
 	for _, v := range report.Report.Vulnerabilities {

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -271,6 +271,7 @@ func getCountPerSeverity(report *aqua.VulnerabilityReport) map[string]float64 {
 // }
 
 func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
+	fmt.Println("publishSummaryMetrics()")
 	summaryValues := valuesForReport(report, LabelsForGroup(labelGroupSummary))
 
 	// Add the severity label after the standard labels and expose each severity metric.
@@ -304,6 +305,7 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 // }
 
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
+	fmt.Println("publishCustomMetrics()")
 	reportValues := valuesForReport(report, targetLabels)
 	fmt.Printf("setting values for report:\nreport.Name: %s\nreport.ObjectMeta.Name: %s\nreportValues[report_name]: %s\n",
 		report.Name, report.ObjectMeta.Name, reportValues["report_name"])

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -351,7 +352,8 @@ func valuesForVulnerability(vuln aqua.Vulnerability, labels []VulnerabilityLabel
 func reportValueFor(field string, report *aqua.VulnerabilityReport) string {
 	switch field {
 	case "report_name":
-		return report.Name
+		return apitypes.NamespacedName{Name: report.Name, Namespace: report.Namespace}
+		// return report.Name
 	case "image_namespace":
 		return report.Namespace
 	case "image_registry":

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
@@ -64,39 +63,25 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	registerMetricsOnce.Do(r.registerMetrics)
 
-	// Once deleting metrics based on partial matches is supported, the logic here will change so we clear the metric for all names not belonging to our shard.
-	// Then we can only fetch reports for our shard. For now, we'll try to get the report once even if it isn't our shard so that we can later clear the metric.
-
-	report := &aqua.VulnerabilityReport{}
-	if err := r.Client.Get(ctx, req.NamespacedName, report); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Most likely the report was deleted.
-			return ctrl.Result{}, nil
-		}
-
-		// Error reading the object.
-		r.Log.Error(err, "Unable to read report")
-		return ctrl.Result{}, err
-	}
-
-	// We have fetched the report and have four possibilities:
-	// - Not deleting + belongs to our shard 			--> give it our label (to trigger reconciliation by any previous owner) and expose the metric.
-	// - Not deleting + does not belong to our shard 	--> remove it from our metrics. Keep the finalizer.
-	// - Deleting + belongs to our shard				--> remove it from our metrics. Remove the finalizer.
-	// - Deleting + does not belong to our shard		--> remove it from our metrics. Keep the finalizer.
+	// The report has changed, meaning our metrics are out of date for this report. Clear them.
+	VulnerabilitySummary.DeletePartialMatch(prometheus.Labels{"report_name": req.NamespacedName.String()})
+	VulnerabilityInfo.DeletePartialMatch(prometheus.Labels{"report_name": req.NamespacedName.String()})
 
 	shouldOwn := r.ShardHelper.ShouldOwn(req.NamespacedName.String())
+	if shouldOwn {
 
-	if report.DeletionTimestamp.IsZero() && shouldOwn {
-
-		// Give the report our finalizer if it doesn't have one.
-		if !utils.SliceContains(report.GetFinalizers(), VulnerabilityReportFinalizer) {
-			ctrlutil.AddFinalizer(report, VulnerabilityReportFinalizer)
-			if err := r.Update(ctx, report); err != nil {
-				return ctrl.Result{}, err
+		// Try to get the report. It might not exist anymore, in which case we don't need to do anything.
+		report := &aqua.VulnerabilityReport{}
+		if err := r.Client.Get(ctx, req.NamespacedName, report); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Most likely the report was deleted.
+				return ctrl.Result{}, nil
 			}
-		}
 
+			// Error reading the object.
+			r.Log.Error(err, "Unable to read report")
+			return ctrl.Result{}, err
+		}
 		r.Log.Info(fmt.Sprintf("Reconciled %s || Found (C/H/M/L/N/U): %d/%d/%d/%d/%d/%d",
 			req.NamespacedName,
 			report.Report.Summary.CriticalCount,
@@ -106,7 +91,6 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 			report.Report.Summary.NoneCount,
 			report.Report.Summary.UnknownCount,
 		))
-
 		// Publish summary and CVE metrics for this report.
 		r.publishImageMetrics(report)
 
@@ -116,25 +100,57 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 		if err != nil {
 			r.Log.Error(err, "unable to add shard owner label")
 		}
-
-	} else {
-		// Unfortunately, we can't yet clear the series based on one label value,
-		// we have to reconstruct all of the label values to delete the series.
-		// That's the only reason the finalizer is needed at all.
-		// So we first clear our metrics for the report, and then remove the finalizer
-		// if we're the shard which owns this report.
-
-		// Drop the report from our metrics.
-		r.clearImageMetrics(report)
-
-		if shouldOwn && utils.SliceContains(report.GetFinalizers(), VulnerabilityReportFinalizer) {
-			// Remove the finalizer if we're the shard owner.
-			ctrlutil.RemoveFinalizer(report, VulnerabilityReportFinalizer)
-			if err := r.Update(ctx, report); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
 	}
+
+	// If we are the shard owner for this report, try to fetch it and expose metrics for it.
+
+	// Once deleting metrics based on partial matches is supported, the logic here will change so we clear the metric for all names not belonging to our shard.
+	// Then we can only fetch reports for our shard. For now, we'll try to get the report once even if it isn't our shard so that we can later clear the metric.
+
+	// We have fetched the report and have four possibilities:
+	// - Not deleting + belongs to our shard 			--> give it our label (to trigger reconciliation by any previous owner) and expose the metric.
+	// - Not deleting + does not belong to our shard 	--> remove it from our metrics. Keep the finalizer.
+	// - Deleting + belongs to our shard				--> remove it from our metrics. Remove the finalizer.
+	// - Deleting + does not belong to our shard		--> remove it from our metrics. Keep the finalizer.
+
+	// if report.DeletionTimestamp.IsZero() && shouldOwn {
+
+	// 	// Give the report our finalizer if it doesn't have one.
+	// 	if !utils.SliceContains(report.GetFinalizers(), VulnerabilityReportFinalizer) {
+	// 		ctrlutil.AddFinalizer(report, VulnerabilityReportFinalizer)
+	// 		if err := r.Update(ctx, report); err != nil {
+	// 			return ctrl.Result{}, err
+	// 		}
+	// 	}
+
+	// 	r.Log.Info(fmt.Sprintf("Reconciled %s || Found (C/H/M/L/N/U): %d/%d/%d/%d/%d/%d",
+	// 		req.NamespacedName,
+	// 		report.Report.Summary.CriticalCount,
+	// 		report.Report.Summary.HighCount,
+	// 		report.Report.Summary.MediumCount,
+	// 		report.Report.Summary.LowCount,
+	// 		report.Report.Summary.NoneCount,
+	// 		report.Report.Summary.UnknownCount,
+	// 	))
+
+	// } else {
+	// 	// Unfortunately, we can't yet clear the series based on one label value,
+	// 	// we have to reconstruct all of the label values to delete the series.
+	// 	// That's the only reason the finalizer is needed at all.
+	// 	// So we first clear our metrics for the report, and then remove the finalizer
+	// 	// if we're the shard which owns this report.
+
+	// 	// Drop the report from our metrics.
+	// 	r.clearImageMetrics(report)
+
+	// 	if shouldOwn && utils.SliceContains(report.GetFinalizers(), VulnerabilityReportFinalizer) {
+	// 		// Remove the finalizer if we're the shard owner.
+	// 		ctrlutil.RemoveFinalizer(report, VulnerabilityReportFinalizer)
+	// 		if err := r.Update(ctx, report); err != nil {
+	// 			return ctrl.Result{}, err
+	// 		}
+	// 	}
+	// }
 
 	return utils.JitterRequeue(controllers.DefaultRequeueDuration, r.MaxJitterPercent, r.Log), nil
 }

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -335,7 +335,7 @@ func valuesForReport(report *aqua.VulnerabilityReport, labels []VulnerabilityLab
 	for _, label := range labels {
 		if label.Scope == FieldScopeReport {
 			result[label.Name] = reportValueFor(label.Name, report)
-			fmt.Printf("result[%s]: %s", label.Name, result[label.Name])
+			fmt.Printf("result[%s]: %s\n", label.Name, result[label.Name])
 		}
 	}
 	fmt.Printf("result: %v\n", result)

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -203,9 +203,9 @@ func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager) error
 // }
 
 func (r *VulnerabilityReportReconciler) publishImageMetrics(report *aqua.VulnerabilityReport) {
-
+	fmt.Printf("Report before publish: %s\n", report.Name)
 	publishSummaryMetrics(report)
-
+	fmt.Printf("Report after publish: %s\n", report.Name)
 	// If we have custom metrics to expose, do it.
 	if len(r.TargetLabels) > 0 {
 		publishCustomMetrics(report, r.TargetLabels)

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -94,6 +94,7 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 			report.Report.Summary.NoneCount,
 			report.Report.Summary.UnknownCount,
 		))
+
 		// Publish summary and CVE metrics for this report.
 		r.publishImageMetrics(report)
 

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -295,7 +295,7 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
 	reportValues := valuesForReport(report, targetLabels)
-	fmt.Println(fmt.Sprintf("setting values for report %s", reportValues["report_name"]))
+	fmt.Printf("setting values for report %s\n", reportValues["report_name"])
 	for _, v := range report.Report.Vulnerabilities {
 		vulnValues := valuesForVulnerability(v, targetLabels)
 

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -65,8 +65,12 @@ func (r *VulnerabilityReportReconciler) Reconcile(ctx context.Context, req ctrl.
 	registerMetricsOnce.Do(r.registerMetrics)
 
 	// The report has changed, meaning our metrics are out of date for this report. Clear them.
-	VulnerabilitySummary.DeletePartialMatch(prometheus.Labels{"report_name": req.NamespacedName.String()})
-	VulnerabilityInfo.DeletePartialMatch(prometheus.Labels{"report_name": req.NamespacedName.String()})
+	deletedSummaries := VulnerabilitySummary.DeletePartialMatch(prometheus.Labels{"report_name": req.NamespacedName.String()})
+	deletedDetails := VulnerabilityInfo.DeletePartialMatch(prometheus.Labels{"report_name": req.NamespacedName.String()})
+	r.Log.Info(fmt.Sprintf("cleared %d summary and %d detail metrics", deletedSummaries, deletedDetails))
+
+	r.Log.Info(fmt.Sprintf("Peer %s should handle report %s", r.ShardHelper.GetShardOwner(req.NamespacedName.String()), req.NamespacedName.String()))
+	r.Log.Info(fmt.Sprintf("This instance should own report: %v", r.ShardHelper.ShouldOwn(req.NamespacedName.String())))
 
 	shouldOwn := r.ShardHelper.ShouldOwn(req.NamespacedName.String())
 	if shouldOwn {

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -182,15 +182,15 @@ func (r *VulnerabilityReportReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return nil
 }
 
-func (r *VulnerabilityReportReconciler) clearImageMetrics(report *aqua.VulnerabilityReport) {
+// func (r *VulnerabilityReportReconciler) clearImageMetrics(report *aqua.VulnerabilityReport) {
 
-	clearSummaryMetrics(report)
+// 	clearSummaryMetrics(report)
 
-	// If we have custom metrics to delete, do it.
-	if len(r.TargetLabels) > 0 {
-		clearCustomMetrics(report, r.TargetLabels)
-	}
-}
+// 	// If we have custom metrics to delete, do it.
+// 	if len(r.TargetLabels) > 0 {
+// 		clearCustomMetrics(report, r.TargetLabels)
+// 	}
+// }
 
 func (r *VulnerabilityReportReconciler) publishImageMetrics(report *aqua.VulnerabilityReport) {
 
@@ -245,20 +245,20 @@ func getCountPerSeverity(report *aqua.VulnerabilityReport) map[string]float64 {
 	}
 }
 
-func clearSummaryMetrics(report *aqua.VulnerabilityReport) {
-	summaryValues := valuesForReport(report, LabelsForGroup(labelGroupSummary))
+// func clearSummaryMetrics(report *aqua.VulnerabilityReport) {
+// 	summaryValues := valuesForReport(report, LabelsForGroup(labelGroupSummary))
 
-	// Delete the series for each severity.
-	for severity := range getCountPerSeverity(report) {
-		v := summaryValues
-		v["severity"] = severity
+// 	// Delete the series for each severity.
+// 	for severity := range getCountPerSeverity(report) {
+// 		v := summaryValues
+// 		v["severity"] = severity
 
-		// Expose the metric.
-		VulnerabilitySummary.Delete(
-			v,
-		)
-	}
-}
+// 		// Expose the metric.
+// 		VulnerabilitySummary.Delete(
+// 			v,
+// 		)
+// 	}
+// }
 
 func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 	summaryValues := valuesForReport(report, LabelsForGroup(labelGroupSummary))
@@ -275,23 +275,23 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 	}
 }
 
-func clearCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
-	reportValues := valuesForReport(report, targetLabels)
+// func clearCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
+// 	reportValues := valuesForReport(report, targetLabels)
 
-	for _, v := range report.Report.Vulnerabilities {
-		vulnValues := valuesForVulnerability(v, targetLabels)
+// 	for _, v := range report.Report.Vulnerabilities {
+// 		vulnValues := valuesForVulnerability(v, targetLabels)
 
-		// Include the Report-level values.
-		for label, value := range reportValues {
-			vulnValues[label] = value
-		}
+// 		// Include the Report-level values.
+// 		for label, value := range reportValues {
+// 			vulnValues[label] = value
+// 		}
 
-		// Delete the metric
-		VulnerabilityInfo.Delete(
-			vulnValues,
-		)
-	}
-}
+// 		// Delete the metric
+// 		VulnerabilityInfo.Delete(
+// 			vulnValues,
+// 		)
+// 	}
+// }
 
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
 	reportValues := valuesForReport(report, targetLabels)

--- a/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
+++ b/controllers/vulnerabilityreport/vulnerabilityreport_controller.go
@@ -305,9 +305,10 @@ func publishSummaryMetrics(report *aqua.VulnerabilityReport) {
 
 func publishCustomMetrics(report *aqua.VulnerabilityReport, targetLabels []VulnerabilityLabel) {
 	reportValues := valuesForReport(report, targetLabels)
-	fmt.Printf("setting values for report %s/%s\n", report.Name, report.ObjectMeta.Name)
-	fmt.Printf("setting values for report %s\n", reportValues["report_name"])
-	fmt.Printf("report:\n%v\n", report)
+	fmt.Printf("setting values for report:\nreport.Name: %s\nreport.ObjectMeta.Name: %s\nreportValues[report_name]: %s\n",
+		report.Name, report.ObjectMeta.Name, reportValues["report_name"])
+	fmt.Printf("report_namespace:\n report.Namespace: %s\n reportValues[image_namespace]: %s\n", report.Namespace, reportValues["image_namespace"])
+	// fmt.Printf("report:\n%v\n", report)
 	for _, v := range report.Report.Vulnerabilities {
 		vulnValues := valuesForVulnerability(v, targetLabels)
 
@@ -352,6 +353,7 @@ func valuesForVulnerability(vuln aqua.Vulnerability, labels []VulnerabilityLabel
 func reportValueFor(field string, report *aqua.VulnerabilityReport) string {
 	switch field {
 	case "report_name":
+		fmt.Printf("found report_name: %s\n", report.Name)
 		return report.Name
 	case "image_namespace":
 		return report.Namespace

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.1
 )
 
-require gotest.tools v2.2.0+incompatible
+require (
+	github.com/google/go-cmp v0.5.8
+	gotest.tools v2.2.0+incompatible
+)
 
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
@@ -40,7 +43,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/go-logr/logr v1.2.3
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.12.2
+	github.com/prometheus/client_golang v1.12.2-0.20220421062905-4dcf02ec7b3c
+	// github.com/prometheus/client_golang v1.12.1
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.1
 )
 
+require gotest.tools v2.2.0+incompatible
+
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1066,6 +1066,8 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0 h1:hjy8E9ON/egN1tAYqKb61G10WtihqetD4sz2H+8nIeA=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
-github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
-github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
+github.com/prometheus/client_golang v1.12.2-0.20220421062905-4dcf02ec7b3c h1:UPm1o0MgQzLM9Vv2RB3xAFgAOi3hIHvpb4fUHSGVxJo=
+github.com/prometheus/client_golang v1.12.2-0.20220421062905-4dcf02ec7b3c/go.mod h1:hnQ3yqQt3g4fD/UXIaxxYrafyiYfxYUS9zsKetoOmXQ=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -456,6 +456,7 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
+github.com/prometheus/common v0.33.0/go.mod h1:gB3sOl7P0TvJabZpLY5uQMpUqRCPPCyRLCZYc7JZTNE=
 github.com/prometheus/common v0.34.0 h1:RBmGO9d/FVjqHT0yUGQwBJhkwKV+wPCn7KGpvfab0uE=
 github.com/prometheus/common v0.34.0/go.mod h1:gB3sOl7P0TvJabZpLY5uQMpUqRCPPCyRLCZYc7JZTNE=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/main.go
+++ b/main.go
@@ -116,6 +116,10 @@ func main() {
 				targetLabels = appendIfNotExists(targetLabels, []vulnerabilityreport.VulnerabilityLabel{label})
 			}
 
+			// If exposing detail metrics, we must always include the report name in order to delete them by name later.
+			reportNameLabel, _ := vulnerabilityreport.LabelWithName("report_name")
+			targetLabels = appendIfNotExists(targetLabels, []vulnerabilityreport.VulnerabilityLabel{reportNameLabel})
+
 			return nil
 		})
 

--- a/utils/sharding.go
+++ b/utils/sharding.go
@@ -160,11 +160,6 @@ func updateEndpoints(currentObj interface{}, previousObj interface{}, ring *Shar
 
 // getEndpointChanges takes a current and optional previous object and returns the added, kept, and removed items, plus a success boolean.
 func getEndpointChanges(current *corev1.Endpoints, previous *corev1.Endpoints, log logr.Logger) ([]string, []string, []string, bool) {
-	// current, err := toEndpoint(currentObj, log)
-	// if err != nil {
-	// 	log.Error(err, "could not convert obj to Endpoints")
-	// 	return nil, nil, nil, false
-	// }
 
 	currentEndpoints := []string{}                   // Stores current endpoints to return directly if we don't have a previous state.
 	currentEndpointsMap := make(map[string]struct{}) // Stores the endpoints as a map for quicker comparisons to previous state.
@@ -184,12 +179,6 @@ func getEndpointChanges(current *corev1.Endpoints, previous *corev1.Endpoints, l
 		// Just return the current endpoint list.
 		return currentEndpoints, nil, nil, true
 	}
-
-	// previous, err := toEndpoint(previousObj, log)
-	// if err != nil {
-	// 	log.Error(err, "could not convert obj to Endpoints")
-	// 	return nil, nil, nil, false
-	// }
 
 	added := []string{}
 	kept := []string{}

--- a/utils/sharding.go
+++ b/utils/sharding.go
@@ -121,7 +121,7 @@ func BuildPeerInformer(stopper chan struct{}, peerRing *ShardHelper, ringConfig 
 			// In the future, we might need to re-queue objects which belong to deleted peers.
 			// When scaling down, it is possible that metrics will be double reported for up to the reconciliation period.
 			// For now, we'll just set the desired peers.
-			updateEndpoints(oldObj, newObj, peerRing, log)
+			updateEndpoints(newObj, oldObj, peerRing, log)
 		},
 		// We can add a delete handler here. Not sure yet what it should do.
 	}
@@ -136,7 +136,7 @@ func updateEndpoints(currentObj interface{}, previousObj interface{}, ring *Shar
 		return
 	}
 	ring.SetMembersFromLists(added, kept)
-	log.Info(fmt.Sprintf("found %d peers from service endpoints", len(added)+len(kept)))
+	log.Info(fmt.Sprintf("updated peer list with %d endpoints", len(added)+len(kept)))
 }
 
 // getEndpointChanges takes a current and optional previous object and returns the added, kept, and removed items, plus a success boolean.

--- a/utils/sharding_test.go
+++ b/utils/sharding_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"sort"
 	"strconv"
 	"testing"
 
@@ -204,10 +203,10 @@ func Test_getEndpointChanges(t *testing.T) {
 			// Calculate endpoint updates.
 			added, kept, removed, ok := getEndpointChanges(tc.current, previous, log)
 
-			t.Logf("case %v: added: %v, kept: %v, removed: %v\n", tc, sort.StringSlice(added), kept, removed)
+			t.Logf("case %v: added: %v, kept: %v, removed: %v\n", tc, added, kept, removed)
 
 			if !ok {
-				t.Fatalf("unable to parse endpoint changes for case %v: added: %s, kept: %s, removed: %s\n", tc, sort.StringSlice(added), kept, removed)
+				t.Fatalf("unable to parse endpoint changes for case %v: added: %s, kept: %s, removed: %s\n", tc, added, kept, removed)
 			}
 
 			compareStringFunc := func(a, b string) bool { return a < b }

--- a/utils/sharding_test.go
+++ b/utils/sharding_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"sort"
 	"strconv"
 	"testing"
 
@@ -37,8 +38,157 @@ func Test_getEndpointChanges(t *testing.T) {
 			expectedKept:    []string{},
 			expectedRemoved: []string{},
 		},
+		{
+			name: "add one new endpoint to one previous endpoint",
+			current: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "5.6.7.8",
+							},
+						},
+					},
+				},
+			},
+			previous: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+			expectedAdded:   []string{"5.6.7.8"},
+			expectedKept:    []string{"1.2.3.4"},
+			expectedRemoved: []string{},
+		},
+		{
+			name: "add multiple new endpoints to two previous endpoints",
+			current: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "8.8.8.8",
+							},
+							{
+								IP: "8.8.4.4",
+							},
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "5.6.7.8",
+							},
+						},
+					},
+				},
+			},
+			previous: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "5.6.7.8",
+							},
+						},
+					},
+				},
+			},
+			expectedAdded:   []string{"8.8.4.4", "8.8.8.8"},
+			expectedKept:    []string{"1.2.3.4", "5.6.7.8"},
+			expectedRemoved: []string{},
+		},
+		{
+			name: "remove multiple endpoints",
+			current: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "8.8.8.8",
+							},
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+			previous: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "8.8.8.8",
+							},
+							{
+								IP: "8.8.4.4",
+							},
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "5.6.7.8",
+							},
+						},
+					},
+				},
+			},
+			expectedAdded:   []string{},
+			expectedKept:    []string{"1.2.3.4", "8.8.8.8"},
+			expectedRemoved: []string{"5.6.7.8", "8.8.4.4"},
+		},
+		{
+			name: "add and remove endpoints in one udpate",
+			current: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "8.8.4.4",
+							},
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "5.6.7.8",
+							},
+						},
+					},
+				},
+			},
+			previous: &corev1.Endpoints{
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "8.8.8.8",
+							},
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+			expectedAdded:   []string{"5.6.7.8", "8.8.4.4"},
+			expectedKept:    []string{"1.2.3.4"},
+			expectedRemoved: []string{"8.8.8.8"},
+		},
 	}
 
+	// Logger to pass to helper functions. Wraps testing.T.
 	log := testr.New(t)
 
 	for i, tc := range testCases {
@@ -51,17 +201,21 @@ func Test_getEndpointChanges(t *testing.T) {
 				}
 			}
 
+			// Calculate endpoint updates.
 			added, kept, removed, ok := getEndpointChanges(tc.current, previous, log)
 
-			t.Logf("case %v: added: %v, kept: %v, removed: %v\n", tc, added, kept, removed)
+			t.Logf("case %v: added: %v, kept: %v, removed: %v\n", tc, sort.StringSlice(added), kept, removed)
 
 			if !ok {
-				t.Fatalf("unable to parse endpoint changes for case %v: added: %s, kept: %s, removed: %s\n", tc, added, kept, removed)
+				t.Fatalf("unable to parse endpoint changes for case %v: added: %s, kept: %s, removed: %s\n", tc, sort.StringSlice(added), kept, removed)
 			}
 
-			assert.Assert(t, cmp.Equal(tc.expectedAdded, added, cmpopts.EquateEmpty()), "test case %v failed.", tc.name)
-			assert.Assert(t, cmp.Equal(tc.expectedKept, kept, cmpopts.EquateEmpty()), "test case %v failed.", tc.name)
-			assert.Assert(t, cmp.Equal(tc.expectedRemoved, removed, cmpopts.EquateEmpty()), "test case %v failed.", tc.name)
+			compareStringFunc := func(a, b string) bool { return a < b }
+
+			// Check added, kept, and removed contain the expected items, ignoring order.
+			assert.Assert(t, cmp.Equal(tc.expectedAdded, added, cmpopts.EquateEmpty(), cmpopts.SortSlices(compareStringFunc)), "test case %v failed.", tc.name)
+			assert.Assert(t, cmp.Equal(tc.expectedKept, kept, cmpopts.EquateEmpty(), cmpopts.SortSlices(compareStringFunc)), "test case %v failed.", tc.name)
+			assert.Assert(t, cmp.Equal(tc.expectedRemoved, removed, cmpopts.EquateEmpty(), cmpopts.SortSlices(compareStringFunc)), "test case %v failed.", tc.name)
 		})
 	}
 }

--- a/utils/sharding_test.go
+++ b/utils/sharding_test.go
@@ -1,0 +1,122 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_getEndpointChanges(t *testing.T) {
+	testCases := []struct {
+		field        string
+		anotherfield string
+	}{
+		{
+			field: "todo",
+		},
+		{
+			field:        "todo",
+			anotherfield: "todo",
+		},
+	}
+
+	// u := &unstructured.Unstructured{
+	// 	Object: map[string]interface{}{
+	// 		"apiVersion": "cr.bar.com/v1",
+	// 		"kind":       "Foo",
+	// 		"spec":       map[string]interface{}{"field": 1},
+	// 		"metadata": map[string]interface{}{
+	// 			"name": "test-1",
+	// 			"annotations": map[string]interface{}{
+	// 				"foo": "bar",
+	// 			},
+	// 		},
+	// 	},
+	// }
+
+	// a1 := map[string]interface{}{
+	// 	"ip":       "10.0.131.187",
+	// 	"nodeName": "worker-000026",
+	// 	"targetRef": map[string]string{
+	// 		"kind":      "Pod",
+	// 		"name":      "starboard-exporter-765756bd69-vzx49",
+	// 		"namespace": "giantswarm",
+	// 	},
+	// }
+
+	// addresses := make([]map[string]interface{})
+	// addresses = append(addresses)
+
+	// ep := &unstructured.Unstructured{
+	// 	Object: map[string]interface{}{
+	// 		"apiVersion": "v1",
+	// 		"kind":       "Endpoints",
+	// 		"metadata": map[string]interface{}{
+	// 			"name":      "starboard-exporter",
+	// 			"namespace": "giantswarm",
+	// 		},
+	// 		// "subsets": map[string][]map[string]interface{}{
+	// 		"subsets": map[string]interface{}{
+	// 			"addresses": []map[string]interface{}{
+	// 				{
+	// 					"ip":       "10.0.131.187",
+	// 					"nodeName": "worker-000026",
+	// 					"targetRef": map[string]string{
+	// 						"kind":      "Pod",
+	// 						"name":      "starboard-exporter-765756bd69-vzx49",
+	// 						"namespace": "giantswarm",
+	// 					},
+	// 				},
+	// 			},
+	// 			"ports": []map[string]interface{}{
+	// 				{
+	// 					"name":     "metrics",
+	// 					"port":     "8080",
+	// 					"protocol": "TCP",
+	// 				},
+	// 			},
+	// 		},
+	// 	},
+	// }
+
+	epp := &corev1.Endpoints{}
+	subsets := corev1.EndpointSubset{
+		Addresses: []corev1.EndpointAddress{
+			{
+				IP: "1.2.3.4",
+				// NodeName: "worker-000026",
+			},
+		},
+	}
+
+	epp.Subsets = []corev1.EndpointSubset{subsets}
+
+	log := testr.New(t)
+
+	for i, testCase := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			log.Info("test")
+			log.Info(fmt.Sprintf("%v", epp))
+			added, kept, removed, ok := getEndpointChanges(epp, nil, log)
+			t.Logf("case %s: added: %s, kept: %s, removed: %s\n", testCase, added, kept, removed)
+
+			if !ok {
+				t.Fatalf("case %s: added: %s, kept: %s, removed: %s\n", testCase, added, kept, removed)
+			}
+		})
+	}
+}
+
+//	{
+//   - ip: 10.0.133.125
+// 	nodeName: worker-000025
+// 	targetRef:
+// 	  kind: Pod
+// 	  name: starboard-exporter-765756bd69-r795x
+// 	  namespace: giantswarm
+// 	  resourceVersion: "694068745"
+// 	  uid: 02758daa-e56a-499f-af8a-fb795890700f
+// 	  }


### PR DESCRIPTION
To support sharding metrics across exporters, it would be nice to get rid of the finalizers added by each controller to their watched aqua resources. The finalizers were only needed because it isn't possible to delete a metric from the golang prometheus client without specifying _all_ of the labels for that metric -- in other words, we had to reconstruct the entire metric (so vulnerability details, etc.) in order to delete it. Finalizers were added to give the exporters an opportunity to clear the metrics before the report is deleted.

I've since [implemented the functionality](https://github.com/prometheus/client_golang/pull/1013) needed in the prometheus client, but this change has not been released yet.

With sharded metrics, the shard owner is responsible for clearing the finalizer after it has cleared its metrics for a given report. However, even the finalizer does not handle all cases where we might miss metrics, for example, when a statefulset is updated as described by https://github.com/giantswarm/starboard-exporter/issues/48. So, I'm committing a minor sin by using an untagged version of the prometheus client in order to a. solve the issue with stale metrics and b. hopefully get us closer to caching fewer reports per instance.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] (Giant Swarm) If creating a release, bump the `version` and `appVersion` in Chart.yaml.
