### PR TITLE
Toggle controllers on and off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow selectively enabling/disabling controllers for each report type.
+
 ## [0.5.0] - 2022-06-22
 
 ### Announcements

--- a/go.mod
+++ b/go.mod
@@ -87,5 +87,5 @@ replace (
 	github.com/coreos/etcd => github.com/coreos/etcd v3.3.27+incompatible
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/miekg/dns => github.com/miekg/dns v1.1.49
-	github.com/open-policy-agent/opa => github.com/open-policy-agent/opa v0.40.0
+	github.com/open-policy-agent/opa v0.40.0 => github.com/open-policy-agent/opa v0.42.2
 )

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,11 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/go-logr/logr v1.2.3
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.12.2-0.20220421062905-4dcf02ec7b3c
-	// github.com/prometheus/client_golang v1.12.1
+	github.com/prometheus/client_golang v1.12.2-0.20220421062905-4dcf02ec7b3c // Waiting for 1.13 release.
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
-	sigs.k8s.io/controller-runtime v0.12.2
+	sigs.k8s.io/controller-runtime v0.12.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1105,8 +1105,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
-sigs.k8s.io/controller-runtime v0.12.2 h1:nqV02cvhbAj7tbt21bpPpTByrXGn2INHRsi39lXy9sE=
-sigs.k8s.io/controller-runtime v0.12.2/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
+sigs.k8s.io/controller-runtime v0.12.3 h1:FCM8xeY/FI8hoAfh/V4XbbYMY20gElh9yh+A98usMio=
+sigs.k8s.io/controller-runtime v0.12.3/go.mod h1:qKsk4WE6zW2Hfj0G4v10EnNB2jMG1C+NTb8h+DwCoU0=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 h1:kDi4JBNAsJWfz1aEXhO8Jg87JJaPNLh5tIzYHgStQ9Y=
 sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2/go.mod h1:B+TnT182UBxE84DiCz4CVE26eOSDAeYCpfDnC2kdKMY=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/helm/starboard-exporter/templates/deployment.yaml
+++ b/helm/starboard-exporter/templates/deployment.yaml
@@ -67,6 +67,7 @@ spec:
         {{- if .Values.exporter.vulnerabilityReports.targetLabels }}
           - --target-labels={{ .Values.exporter.vulnerabilityReports.targetLabels | join "," }}
         {{- end }}
+          - --cis-benchmark-enabled={{ default .Values.exporter.CISKubeBenchReports.enabled true }}
         {{- if .Values.exporter.CISKubeBenchReports.targetLabels }}
           - --cis-detail-report-labels={{ .Values.exporter.CISKubeBenchReports.targetLabels | join "," }}
         {{- end }}

--- a/helm/starboard-exporter/templates/deployment.yaml
+++ b/helm/starboard-exporter/templates/deployment.yaml
@@ -67,10 +67,10 @@ spec:
         {{- if .Values.exporter.vulnerabilityReports.targetLabels }}
           - --target-labels={{ .Values.exporter.vulnerabilityReports.targetLabels | join "," }}
         {{- end }}
-          # A little magic for handling defaulting with booleans https://github.com/helm/helm/issues/3308#issuecomment-781523784
-          - --cis-benchmarks-enabled={{ or .Values.exporter.CISKubeBenchReports.enabled (not (hasKey .Values.exporter.CISKubeBenchReports "enabled")) }}
-          - --config-audits-enabled={{ or .Values.exporter.configAuditReports.enabled (not (hasKey .Values.exporter.configAuditReports "enabled")) }}
-          - --vulnerability-scans-enabled={{ or .Values.exporter.vulnerabilityReports.enabled (not (hasKey .Values.exporter.vulnerabilityReports "enabled")) }}
+          # A little magic for handling defaulting with booleans https://github.com/helm/helm/issues/3308#issuecomment-701367019
+          - --cis-benchmarks-enabled={{ hasKey .Values.exporter.CISKubeBenchReports "enabled" | ternary .Values.exporter.CISKubeBenchReports.enabled true }}
+          - --config-audits-enabled={{ hasKey .Values.exporter.configAuditReports "enabled" | ternary .Values.exporter.configAuditReports.enabled true }}
+          - --vulnerability-scans-enabled={{ hasKey .Values.exporter.vulnerabilityReports "enabled" | ternary .Values.exporter.vulnerabilityReports.enabled true }}
         {{- if .Values.exporter.CISKubeBenchReports.targetLabels }}
           - --cis-detail-report-labels={{ .Values.exporter.CISKubeBenchReports.targetLabels | join "," }}
         {{- end }}

--- a/helm/starboard-exporter/templates/deployment.yaml
+++ b/helm/starboard-exporter/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
           - --target-labels={{ .Values.exporter.vulnerabilityReports.targetLabels | join "," }}
         {{- end }}
           - --cis-benchmarks-enabled={{ default .Values.exporter.CISKubeBenchReports.enabled true }}
+          - --config-audits-enabled={{ default .Values.exporter.configAuditReports.enabled true }}
+          - --vulnerability-scans-enabled={{ default .Values.exporter.vulnerabilityReports.enabled true }}
         {{- if .Values.exporter.CISKubeBenchReports.targetLabels }}
           - --cis-detail-report-labels={{ .Values.exporter.CISKubeBenchReports.targetLabels | join "," }}
         {{- end }}

--- a/helm/starboard-exporter/templates/deployment.yaml
+++ b/helm/starboard-exporter/templates/deployment.yaml
@@ -67,9 +67,10 @@ spec:
         {{- if .Values.exporter.vulnerabilityReports.targetLabels }}
           - --target-labels={{ .Values.exporter.vulnerabilityReports.targetLabels | join "," }}
         {{- end }}
-          - --cis-benchmarks-enabled={{ default .Values.exporter.CISKubeBenchReports.enabled true }}
-          - --config-audits-enabled={{ default .Values.exporter.configAuditReports.enabled true }}
-          - --vulnerability-scans-enabled={{ default .Values.exporter.vulnerabilityReports.enabled true }}
+          # A little magic for handling defaulting with booleans https://github.com/helm/helm/issues/3308#issuecomment-781523784
+          - --cis-benchmarks-enabled={{ or .Values.exporter.CISKubeBenchReports.enabled (not (hasKey .Values.exporter.CISKubeBenchReports "enabled")) }}
+          - --config-audits-enabled={{ or .Values.exporter.configAuditReports.enabled (not (hasKey .Values.exporter.configAuditReports "enabled")) }}
+          - --vulnerability-scans-enabled={{ or .Values.exporter.vulnerabilityReports.enabled (not (hasKey .Values.exporter.vulnerabilityReports "enabled")) }}
         {{- if .Values.exporter.CISKubeBenchReports.targetLabels }}
           - --cis-detail-report-labels={{ .Values.exporter.CISKubeBenchReports.targetLabels | join "," }}
         {{- end }}

--- a/helm/starboard-exporter/templates/deployment.yaml
+++ b/helm/starboard-exporter/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         {{- if .Values.exporter.vulnerabilityReports.targetLabels }}
           - --target-labels={{ .Values.exporter.vulnerabilityReports.targetLabels | join "," }}
         {{- end }}
-          - --cis-benchmark-enabled={{ default .Values.exporter.CISKubeBenchReports.enabled true }}
+          - --cis-benchmarks-enabled={{ default .Values.exporter.CISKubeBenchReports.enabled true }}
         {{- if .Values.exporter.CISKubeBenchReports.targetLabels }}
           - --cis-detail-report-labels={{ .Values.exporter.CISKubeBenchReports.targetLabels | join "," }}
         {{- end }}

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -45,7 +45,7 @@ project:
 
 exporter:
   requeueMaxJitterPercent: 10
- 
+
   CISKubeBenchReports:
     enabled: true
     targetLabels:

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -52,6 +52,7 @@ exporter:
       # - image_tag
       # - vulnerability_id
   CISKubeBenchReports:
+    enabled: true
     targetLabels:
       # - test_number
       # - test_desc

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -45,21 +45,25 @@ project:
 
 exporter:
   requeueMaxJitterPercent: 10
-  vulnerabilityReports:
-    enabled: false
-    targetLabels:
-      # - image_namespace
-      # - image_repository
-      # - image_tag
-      # - vulnerability_id
+  
   CISKubeBenchReports:
-    enabled: false
+    enabled: true
     targetLabels:
       # - test_number
       # - test_desc
       # - test_status
+  
   configAuditReports:
-    enabled: false
+    enabled: true
+
+  vulnerabilityReports:
+      enabled: true
+      targetLabels:
+        # - image_namespace
+        # - image_repository
+        # - image_tag
+        # - vulnerability_id
+
 
 monitoring:
   serviceMonitor:

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -46,6 +46,7 @@ project:
 exporter:
   requeueMaxJitterPercent: 10
   vulnerabilityReports:
+    enabled: true
     targetLabels:
       # - image_namespace
       # - image_repository
@@ -57,6 +58,8 @@ exporter:
       # - test_number
       # - test_desc
       # - test_status
+  configAuditReports:
+    enabled: true
 
 monitoring:
   serviceMonitor:

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -53,7 +53,7 @@ exporter:
       # - image_tag
       # - vulnerability_id
   CISKubeBenchReports:
-    enabled: true
+    enabled: false
     targetLabels:
       # - test_number
       # - test_desc

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -45,25 +45,24 @@ project:
 
 exporter:
   requeueMaxJitterPercent: 10
-  
+ 
   CISKubeBenchReports:
     enabled: true
     targetLabels:
       # - test_number
       # - test_desc
       # - test_status
-  
+
   configAuditReports:
     enabled: true
 
   vulnerabilityReports:
-      enabled: true
-      targetLabels:
-        # - image_namespace
-        # - image_repository
-        # - image_tag
-        # - vulnerability_id
-
+    enabled: true
+    targetLabels:
+      # - image_namespace
+      # - image_repository
+      # - image_tag
+      # - vulnerability_id
 
 monitoring:
   serviceMonitor:

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -46,7 +46,7 @@ project:
 exporter:
   requeueMaxJitterPercent: 10
   vulnerabilityReports:
-    enabled: true
+    enabled: false
     targetLabels:
       # - image_namespace
       # - image_repository
@@ -59,7 +59,7 @@ exporter:
       # - test_desc
       # - test_status
   configAuditReports:
-    enabled: true
+    enabled: false
 
 monitoring:
   serviceMonitor:

--- a/main.go
+++ b/main.go
@@ -272,6 +272,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
+
 	if vulnerabilityScansEnabled {
 		if err = (&vulnerabilityreport.VulnerabilityReportReconciler{
 			Client:           mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func main() {
 			return nil
 		})
 
-	flag.BoolVar(&configAuditEnabled, "config-audit-enabled", true,
+	flag.BoolVar(&configAuditEnabled, "config-audits-enabled", true,
 		"Enable metrics for CIS benchmarks based on CISKubeBenchReport resources.")
 
 	flag.BoolVar(&vulnerabilityScansEnabled, "vulnerability-scans-enabled", true,

--- a/main.go
+++ b/main.go
@@ -74,13 +74,16 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
+	var cisBenchmarkEnabled bool
+	var configAuditEnabled bool
 	var enableLeaderElection bool
 	var maxJitterPercent int
+	var metricsAddr string
 	var podIPString string
 	var probeAddr string
 	var serviceName string
 	var serviceNamespace string
+	var vulnerabilityScansEnabled bool
 	targetLabels := []vulnerabilityreport.VulnerabilityLabel{}
 	cisReportLabels := []ciskubebenchreport.ReportLabel{}
 
@@ -125,6 +128,9 @@ func main() {
 			return nil
 		})
 
+	flag.BoolVar(&cisBenchmarkEnabled, "cis-benchmarks-enabled", true,
+		"Enable metrics for CIS benchmarks based on CISKubeBenchReport resources.")
+
 	flag.Func("cis-detail-report-labels",
 		"A comma-separated list of labels to be exposed from each CIS benchmark detail report. Alias 'all' is supported.",
 		func(input string) error {
@@ -150,6 +156,12 @@ func main() {
 
 			return nil
 		})
+
+	flag.BoolVar(&configAuditEnabled, "config-audit-enabled", true,
+		"Enable metrics for CIS benchmarks based on CISKubeBenchReport resources.")
+
+	flag.BoolVar(&vulnerabilityScansEnabled, "vulnerability-scans-enabled", true,
+		"Enable metrics for CIS benchmarks based on CISKubeBenchReport resources.")
 
 	opts := zap.Options{
 		Development: true,
@@ -234,40 +246,46 @@ func main() {
 
 	setupLog.Info(fmt.Sprintf("found %d exporters in %s service", peerRing.MemberCount(), peerRing.ServiceName))
 
-	if err = (&vulnerabilityreport.VulnerabilityReportReconciler{
-		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("controllers").WithName("VulnerabilityReport"),
-		MaxJitterPercent: maxJitterPercent,
-		Scheme:           mgr.GetScheme(),
-		ShardHelper:      peerRing,
-		TargetLabels:     targetLabels,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "VulnerabilityReport")
-		os.Exit(1)
+	if cisBenchmarkEnabled {
+		if err = (&ciskubebenchreport.CISKubeBenchReportReconciler{
+			Client:           mgr.GetClient(),
+			Log:              ctrl.Log.WithName("controllers").WithName("CISKubeBenchReport"),
+			MaxJitterPercent: maxJitterPercent,
+			Scheme:           mgr.GetScheme(),
+			ShardHelper:      peerRing,
+			TargetLabels:     cisReportLabels,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "CISKubeBenchReport")
+			os.Exit(1)
+		}
 	}
 
-	if err = (&configauditreport.ConfigAuditReportReconciler{
-		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("controllers").WithName("ConfigAuditReport"),
-		MaxJitterPercent: maxJitterPercent,
-		Scheme:           mgr.GetScheme(),
-		ShardHelper:      peerRing,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ConfigAuditReport")
-		os.Exit(1)
+	if configAuditEnabled {
+		if err = (&configauditreport.ConfigAuditReportReconciler{
+			Client:           mgr.GetClient(),
+			Log:              ctrl.Log.WithName("controllers").WithName("ConfigAuditReport"),
+			MaxJitterPercent: maxJitterPercent,
+			Scheme:           mgr.GetScheme(),
+			ShardHelper:      peerRing,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ConfigAuditReport")
+			os.Exit(1)
+		}
+	}
+	if vulnerabilityScansEnabled {
+		if err = (&vulnerabilityreport.VulnerabilityReportReconciler{
+			Client:           mgr.GetClient(),
+			Log:              ctrl.Log.WithName("controllers").WithName("VulnerabilityReport"),
+			MaxJitterPercent: maxJitterPercent,
+			Scheme:           mgr.GetScheme(),
+			ShardHelper:      peerRing,
+			TargetLabels:     targetLabels,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "VulnerabilityReport")
+			os.Exit(1)
+		}
 	}
 
-	if err = (&ciskubebenchreport.CISKubeBenchReportReconciler{
-		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("controllers").WithName("CISKubeBenchReport"),
-		MaxJitterPercent: maxJitterPercent,
-		Scheme:           mgr.GetScheme(),
-		ShardHelper:      peerRing,
-		TargetLabels:     cisReportLabels,
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "CISKubeBenchReport")
-		os.Exit(1)
-	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 		})
 
 	flag.BoolVar(&cisBenchmarkEnabled, "cis-benchmarks-enabled", true,
-		"Enable metrics for CIS benchmarks based on CISKubeBenchReport resources.")
+		"Enable metrics for CISKubeBenchReport resources.")
 
 	flag.Func("cis-detail-report-labels",
 		"A comma-separated list of labels to be exposed from each CIS benchmark detail report. Alias 'all' is supported.",
@@ -158,10 +158,10 @@ func main() {
 		})
 
 	flag.BoolVar(&configAuditEnabled, "config-audits-enabled", true,
-		"Enable metrics for CIS benchmarks based on CISKubeBenchReport resources.")
+		"Enable metrics for ConfigAuditReport resources.")
 
 	flag.BoolVar(&vulnerabilityScansEnabled, "vulnerability-scans-enabled", true,
-		"Enable metrics for CIS benchmarks based on CISKubeBenchReport resources.")
+		"Enable metrics for VulnerabilityReport resources.")
 
 	opts := zap.Options{
 		Development: true,


### PR DESCRIPTION
As part of the `starboard` --> `trivy-operator` move, upstream is making lots of changes to which CRDs are supported/installed. Adding these flags allows the exporter to run in clusters where, for example, the CISKubeBenchReport CRD has been removed.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] (Giant Swarm) If creating a release, bump the `version` and `appVersion` in Chart.yaml.
