### PR TITLE
Disable CIS benchmark report reconciliation by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `podLabels` property to allow custom pod labels.
 
-## [0.5.2] - 2022-09-09
+### Changed
 
+- Disable reconciliation of CIS benchmark reports by default. These reports are temporarily removed from `trivy-operator`, to be reintroduced in the future. Reconciliation of CIS benchmarks produced by `starboard` is still supported by setting `exporter.CISKubeBenchReports.enabled: true` in the Helm values.
+
+## [0.5.2] - 2022-09-09
 
 ### Added
 

--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -50,7 +50,7 @@ exporter:
   requeueMaxJitterPercent: 10
 
   CISKubeBenchReports:
-    enabled: true
+    enabled: false
     targetLabels:
       # - test_number
       # - test_desc


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/22754

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] (Giant Swarm) If creating a release, bump the `version` and `appVersion` in Chart.yaml.
