### PR TITLE
Enforce PodSecurityStandards since psp disappeared in 1.25

### DIFF
--- a/helm/starboard-exporter/values.yaml
+++ b/helm/starboard-exporter/values.yaml
@@ -9,7 +9,7 @@ imagePullSecrets: {}
 
 global:
   podSecurityStandards:
-    enforced: false
+    enforced: true
 
 pod:
   user:


### PR DESCRIPTION
Pod Security Policies were removed in kubernetes 1.25 and the default chart fails to install on a modern cluster running 1.29.2

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] (Giant Swarm) If creating a release, bump the `version` and `appVersion` in Chart.yaml.
