### PR TITLE
Disable logger development mode to avoid panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Vertical Pod Autoscaler (VPA) configuration, enabled by default.
 
+### Changed
+
+- Disable logger development mode to avoid panicking
+
 ## [0.7.11] - 2024-06-12
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func main() {
 		"Enable metrics for VulnerabilityReport resources.")
 
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
Towards: [#3657](https://github.com/giantswarm/roadmap/issues/3657)
This PR: 

- disables logger development mode to avoid panicking


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] (Giant Swarm) If creating a release, bump the `version` and `appVersion` in Chart.yaml.
