### PR TITLE
fix: disable watch-list semantics for kubescape VulnerabilityManifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Configure RBAC for only enabled controllers in Helm Chart.
+- Disable `WatchList` semantics for kubescape VulnerabilityManifest.
 
 ### Added
 

--- a/main.go
+++ b/main.go
@@ -195,6 +195,8 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "58aff8fc.giantswarm",
 		Cache: cache.Options{
+			// TODO: Remove this workaround when WatchList supported in kubescape
+			// https://github.com/kubescape/storage/issues/320
 			NewInformer: func(lw toolscache.ListerWatcher, obj runtime.Object, resyncPeriod time.Duration, indexers toolscache.Indexers) toolscache.SharedIndexInformer {
 				if _, ok := obj.(*kubescape.VulnerabilityManifest); ok {
 					lw = watchListSemanticsDisabledListerWatcherWrapper{lw}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -41,6 +42,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,6 +64,14 @@ var (
 )
 
 type hasher struct{}
+
+type watchListSemanticsDisabledListerWatcherWrapper struct {
+	toolscache.ListerWatcher
+}
+
+func (w watchListSemanticsDisabledListerWatcherWrapper) IsWatchListSemanticsUnSupported() bool {
+	return true
+}
 
 func (h hasher) Sum64(data []byte) uint64 {
 	// TODO: Investigate hash function options.
@@ -184,6 +194,14 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "58aff8fc.giantswarm",
+		Cache: cache.Options{
+			NewInformer: func(lw toolscache.ListerWatcher, obj runtime.Object, resyncPeriod time.Duration, indexers toolscache.Indexers) toolscache.SharedIndexInformer {
+				if _, ok := obj.(*kubescape.VulnerabilityManifest); ok {
+					lw = watchListSemanticsDisabledListerWatcherWrapper{lw}
+				}
+				return toolscache.NewSharedIndexInformer(lw, obj, resyncPeriod, indexers)
+			},
+		},
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 			baseCache, err := cache.New(config, opts)
 			if err != nil {


### PR DESCRIPTION
Disables WatchList for kubescape.VulnerabilityManifest:

https://github.com/kubernetes/kubernetes/blob/ec62fa4dca405a65f04a68c2b6c90777de28fb58/staging/src/k8s.io/client-go/util/watchlist/watch_list.go#L88-L102

https://github.com/kubernetes/kubernetes/blob/ec62fa4dca405a65f04a68c2b6c90777de28fb58/staging/src/k8s.io/client-go/tools/cache/reflector.go#L361-L371

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] (Giant Swarm) If creating a release, bump the `version` and `appVersion` in Chart.yaml.
