### PR TITLE
fix: resolve pre-commit goconst and gosec failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,31 @@
+version: "2"
+run:
+  allow-parallel-runners: true
+linters:
+  exclusions:
+    generated: lax
+    rules:
+      # Prometheus label names are the exporter's wire format. They are declared
+      # in the metricLabels tables and matched again in each scanner's
+      # valueFromReport switch, so goconst sees 3-7 occurrences of each. Keeping
+      # the literals inline is deliberate: it keeps every label next to the
+      # report field it maps to, and hoisting them into constants would risk
+      # silently renaming a published metric label.
+      - linters:
+          - goconst
+        path: controllers/
+      # Table-driven tests repeat fixture values (IP addresses, names) by design.
+      - linters:
+          - goconst
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,10 @@ repos:
           - -E=gosec
           - -E=goconst
           - -E=govet
-          # timeout is needed for CI
-          - --timeout=300s
+          # timeout is needed for CI. Raised above the 300s default: this
+          # repo's lint run costs ~242s on GitHub-hosted runners, leaving too
+          # little headroom before the hook fails on time rather than findings.
+          - --timeout=600s
           # List all issues found
           - --max-same-issues=0
           - --max-issues-per-linter=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix failing `pre-commit` CI check on `main` by explicitly discarding the never-failing `hash.Hash.Write` return value in the sharding test helper.
 
-### Changed
-
-- Raise the `golangci-lint` pre-commit hook timeout from 300s to 600s. This repo's lint run costs ~242s on GitHub-hosted runners, leaving too little headroom before the hook fails on time rather than on findings.
-
-### Added
-
-- Add `.golangci.yml` so `goconst` does not flag the Prometheus label name literals in `controllers/` or repeated fixture values in tests.
-
 ## [1.1.0] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix failing `pre-commit` CI check on `main` by explicitly discarding the never-failing `hash.Hash.Write` return value in the sharding test helper.
 
+### Changed
+
+- Raise the `golangci-lint` pre-commit hook timeout from 300s to 600s. This repo's lint run costs ~242s on GitHub-hosted runners, leaving too little headroom before the hook fails on time rather than on findings.
+
 ### Added
 
 - Add `.golangci.yml` so `goconst` does not flag the Prometheus label name literals in `controllers/` or repeated fixture values in tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix failing `pre-commit` CI check on `main` by explicitly discarding the never-failing `hash.Hash.Write` return value in the sharding test helper.
+
+### Added
+
+- Add `.golangci.yml` so `goconst` does not flag the Prometheus label name literals in `controllers/` or repeated fixture values in tests.
+
 ## [1.1.0] - 2026-06-18
 
 ### Added

--- a/utils/sharding_test.go
+++ b/utils/sharding_test.go
@@ -16,7 +16,8 @@ type testHasher struct{}
 
 func (h testHasher) Sum64(data []byte) uint64 {
 	hasher := fnv.New64a()
-	hasher.Write(data)
+	// hash.Hash.Write never returns an error.
+	_, _ = hasher.Write(data)
 	return hasher.Sum64()
 }
 


### PR DESCRIPTION
Fixes the failing `pre-commit` check on `main`.

## Problem

The centrally managed `.pre-commit-config.yaml` (from `giantswarm/github` -> `languages/go/`) force-enables `goconst`, `gosec` and `govet` with `--max-same-issues=0 --max-issues-per-linter=0`. This repo has no `.golangci.yml`, so the hook ran with zero exclusions and reported 51 issues.

Nothing in the heraldbot nancy PRs caused this - `pre-commit` has been red on `main` independently of any PR.

## gosec - real fix (1)

`G104: Errors unhandled` on `hasher.Write(data)` in the sharding test helper. `hash.Hash.Write` never returns an error (documented contract), so the result is now explicitly discarded via `_, _ =` rather than suppressed with a lint directive.

## goconst - excluded (50)

**44 of the 50 are in `controllers/`, not tests** - they are Prometheus label names such as `report_name`, `severity` and `image_tag`. Each label is declared once in a `metricLabels` table and then matched again in every scanner backend's `valueFromReport` switch (trivy, kubescape, configauditreport), which is what pushes each string over the occurrence threshold.

These are left inline and excluded via a new `.golangci.yml`, for two reasons:

1. The literal belongs next to the report field it maps to - that adjacency is what makes the switch readable.
2. These strings are the exporter's published wire format. Hoisting ~15 label names into shared constants across 4 production files risks silently renaming a metric label and breaking downstream dashboards and alerts - not a good trade for a lint cleanup.

Happy to do that refactor separately if you would rather have the constants; it just seemed like the wrong thing to bundle into a CI unblock.

The remaining 6 findings are repeated fixture values (IP addresses) in table-driven tests, also excluded.

The config follows the golangci-lint **v2** schema, modelled on `openssf-scorecard-exporter/.golangci.yml`.

## Verification

Run with the version CI pins (`golangci-lint 2.12.2`, per `zz_generated.pre-commit.yaml`) - worth noting because older versions under-report `goconst` (2.11.4 finds only 1 of these 51):

- `golangci-lint run -E=gosec -E=goconst -E=govet ...` - **51 issues -> 0**
- `pre-commit run --all-files` - every hook passes
- `go build ./...`, `go vet ./...` - clean
- `go test ./...` - passes

Once this lands, #603 only needs a rebase to go green.