### PR TITLE
fix(nancy): ignore CVE-2022-3248 in github.com/openshift/api

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -25,3 +25,4 @@ CVE-2026-17106 until=2026-09-27 # github.com/moby/go-archive@v0.2.0
 CVE-2026-56864 until=2026-09-27 # golang.org/x/mod@v0.38.0
 CVE-2026-56865 until=2026-09-27 # golang.org/x/mod@v0.38.0
 CVE-2026-46603 until=2026-09-27 # golang.org/x/image@v0.44.0
+CVE-2022-3248 until=2026-10-03 # github.com/openshift/api@v0.0.0-20231025170628-b8a18fdc040d


### PR DESCRIPTION
The v1.2.11 build failed the nancy scan on CVE-2022-3248 in `github.com/openshift/api@v0.0.0-20231025170628-b8a18fdc040d`, so no chart was published for that release.

There is no upgrade path: the module is a transitive requirement of `github.com/aquasecurity/trivy-operator`, and v0.34.0 pins the same pseudo-version as the v0.33.0 we use.

It is also module-graph-only. Nancy scans `go list -json -m all`, which includes modules nothing imports; `github.com/openshift/api` has no `go.sum` entry, so none of its code is compiled into the binary.

Adds the CVE to `.nancy-ignore` with a 30-day review date, matching #618.